### PR TITLE
Fix clickthrough menu bar problem

### DIFF
--- a/src/components/MenuBar.svelte
+++ b/src/components/MenuBar.svelte
@@ -13,5 +13,6 @@
 		position: sticky;
 		bottom: 0;
 		isolation: isolate;
+		z-index: 1;
 	}
 </style>


### PR DESCRIPTION
This fixes the problem described in #536. Adding a z-index prevent the event handler of kana buttons to catch the event when clicking on buttons in the menu bar.