### PR TITLE
Fixed summary screen tooltip problem (leidNedyA#538)

### DIFF
--- a/src/routes/summary/_Tooltip.svelte
+++ b/src/routes/summary/_Tooltip.svelte
@@ -120,7 +120,7 @@
 <style>
 	.tooltip {
 		position: absolute;
-		z-index: 1;
+		z-index: 2;
 		width: 100%;
 	}
 


### PR DESCRIPTION
Closes #538 

Good old `z-index` `:)`

## Before
[Screencast from 07-16-2024 02:58:49 PM.webm](https://github.com/user-attachments/assets/e9618a2e-f777-4b28-bfa3-f8106b4b8761)

## Now
[Screencast from 07-17-2024 10:50:24 PM.webm](https://github.com/user-attachments/assets/decd005b-67db-4fa9-af3f-9488461219e9)
