### PR TITLE
Show session and kana time on summary screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ If you are just looking to play, a hosted version of whatever is currently on th
 
 ## Quick start
 
-Make sure you have at least Node.js 14 installed, then run this in your shell:
+Make sure you have at least Node.js 16 installed, then run this in your shell:
 
 ```bash
 npm install

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -42,3 +42,12 @@ export function uniqArray<T>(array: T[]): T[] {
 export function clamp(min: number, num: number, max: number): number {
 	return num <= min ? min : num >= max ? max : num
 }
+
+export function prettyTime(seconds: number): string {
+	const hours = Math.floor(seconds / 3600)
+	const minutes = Math.floor((seconds % 3600) / 60)
+	const secs =
+		seconds <= 60 ? (seconds % 60).toFixed(1) : Math.floor(seconds % 60)
+
+	return `${hours ? `${hours}h ` : ""}${minutes ? `${minutes}m ` : ""}${secs}s`
+}

--- a/src/routes/session/_Menu.svelte
+++ b/src/routes/session/_Menu.svelte
@@ -3,6 +3,7 @@
 	import Icon from "$/components/MaterialIcon.svelte"
 	import { createEventDispatcher, onMount } from "svelte"
 	import { loadDropSound, loadVictorySound, playDropSound } from "$/lib/sound"
+	import { quiz } from "$/stores/quiz"
 
 	const dispatch = createEventDispatcher()
 
@@ -67,6 +68,9 @@
 		title="Finish session"
 		on:mouseenter={() => {
 			loadVictorySound()
+		}}
+		on:click={() => {
+			quiz.updateDuration()
 		}}
 	>
 		<Icon path={mdiCheck} />

--- a/src/routes/session/_Menu.svelte
+++ b/src/routes/session/_Menu.svelte
@@ -69,9 +69,6 @@
 		on:mouseenter={() => {
 			loadVictorySound()
 		}}
-		on:click={() => {
-			quiz.updateDuration()
-		}}
 	>
 		<Icon path={mdiCheck} />
 	</a>

--- a/src/routes/session/index.svelte
+++ b/src/routes/session/index.svelte
@@ -128,13 +128,8 @@
 		loadMinimizeSound()
 	})
 
-	// Update duration and go to results if queue is empty
-	$: if (unquizzed.length === 0) {
-		quiz.updateDuration()
-		setTimeout(() => {
-			goto("summary")
-		}, 500)
-	}
+	// go to results if queue is empty
+	$: unquizzed.length === 0 && setTimeout(() => goto("summary"), 500)
 </script>
 
 <svelte:head>

--- a/src/routes/session/index.svelte
+++ b/src/routes/session/index.svelte
@@ -28,6 +28,7 @@
 	let streakLength = 0
 	let inputElement: HTMLInputElement
 	let lastQuizzedElement: HTMLDivElement
+	let time = Date.now()
 
 	$: unquizzed = $quiz.unquizzed
 	$: quizzed = $quiz.quizzed
@@ -81,7 +82,7 @@
 			playErrorSound()
 			streakLength = 0
 
-			// Add item back at the end of queue at a random position;
+			// Add item back at the end of queue at a random position
 			if ($settings.retryIncorrectAnswers) {
 				const index = Math.min(randomInt(5, 12), unquizzed.length)
 				quiz.insert(index, currentItem)
@@ -91,8 +92,12 @@
 		quiz.pop((item) => ({
 			...item,
 			answered: input,
-			isCorrectAnswer: isCorrectAnswer(input, item.kana)
+			isCorrectAnswer: isCorrectAnswer(input, item.kana),
+			duration: item.duration ?? 0 + Date.now() - time
 		}))
+
+		// Reset time for next kana
+		time = Date.now()
 
 		if (unquizzed.length < 5) {
 			prefetch("summary")
@@ -123,8 +128,13 @@
 		loadMinimizeSound()
 	})
 
-	// go to results if queue is empty
-	$: unquizzed.length === 0 && setTimeout(() => goto("summary"), 500)
+	// Update duration and go to results if queue is empty
+	$: if (unquizzed.length === 0) {
+		quiz.updateDuration()
+		setTimeout(() => {
+			goto("summary")
+		}, 500)
+	}
 </script>
 
 <svelte:head>

--- a/src/routes/summary/_SummaryBox.svelte
+++ b/src/routes/summary/_SummaryBox.svelte
@@ -4,6 +4,7 @@
 
 	export let items: SummaryKana[]
 	export let fill = true
+	export let time = false
 	export let truncateAt = Infinity
 
 	let expanded = false
@@ -16,7 +17,7 @@
 
 <div class="summary-box">
 	{#each truncatedItems as item (item.kana)}
-		<SummaryItem {item} {fill} />
+		<SummaryItem {time} {item} {fill} />
 	{/each}
 	{#if shouldTruncate}
 		<button

--- a/src/routes/summary/_SummaryItem.svelte
+++ b/src/routes/summary/_SummaryItem.svelte
@@ -2,31 +2,46 @@
 	import type { SummaryKana } from "$/stores/summary"
 	import { isHiragana, isKatakana } from "wanakana"
 	import { tooltip } from "./_Tooltip.svelte"
+	import { prettyTime } from "$lib/util"
 
 	export let item: SummaryKana
 	export let fill = false
+	export let time = false
 </script>
 
-<div
-	class="summary-item"
-	class:hiragana={isHiragana(item.kana)}
-	class:katakana={isKatakana(item.kana)}
-	class:fill
-	tabindex="0"
-	use:tooltip={item}
->
-	{item.kana}
-	{#if item.incorrectTimes > 1}
-		<span
-			class="badge"
-			aria-label="answered incorrectly {item.incorrectTimes} times"
-		>
-			x{item.incorrectTimes}
-		</span>
+<div class="summary-container">
+	<div
+		class="summary-item"
+		class:hiragana={isHiragana(item.kana)}
+		class:katakana={isKatakana(item.kana)}
+		class:fill
+		tabindex="0"
+		use:tooltip={!time ? item : undefined}
+	>
+		{item.kana}
+		{#if item.incorrectTimes > 1}
+			<span
+				class="badge"
+				aria-label="answered incorrectly {item.incorrectTimes} times"
+			>
+				x{item.incorrectTimes}
+			</span>
+		{/if}
+	</div>
+	{#if time}
+		<div class="summary-time">
+			{prettyTime(item.duration / 1000)}
+		</div>
 	{/if}
 </div>
 
 <style lang="postcss">
+	.summary-container {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+	}
+
 	.summary-item {
 		--border-size: 3px;
 
@@ -49,6 +64,14 @@
 		&:focus-visible {
 			border-color: var(--focus-color);
 		}
+	}
+
+	.summary-time {
+		margin-top: var(--gap);
+		margin-left: 1em;
+		line-height: 1;
+		font-family: "M+ 2c";
+		color: var(--text-color);
 	}
 
 	.badge {

--- a/src/routes/summary/index.svelte
+++ b/src/routes/summary/index.svelte
@@ -11,10 +11,13 @@
 	import Icon from "$/components/MaterialIcon.svelte"
 	import { mdiArrowLeft, mdiRestart } from "@mdi/js"
 	import ProgressBar from "$/components/ProgressBar.svelte"
+	import { quiz } from "$/stores/quiz"
+	import { prettyTime } from "$lib/util"
 
 	$: correct = $summary.correct
 	$: incorrect = $summary.incorrect
 	$: unquizzed = $summary.unquizzed
+	$: duration = $summary.duration
 
 	$: answered = correct.length + incorrect.length
 	$: accuracy = correct.length / answered
@@ -43,7 +46,10 @@
 			{Math.round(accuracy * 100)}% correct,
 		{/if}
 		{answered}{answered !== total ? "/" + total : ""}
-		answered
+		answered,
+		{#if duration}
+			{prettyTime(duration)}
+		{/if}
 	</p>
 
 	{#if correct.length > 0}
@@ -80,16 +86,32 @@
 			<SummaryBox items={unquizzed} fill={false} truncateAt={15} />
 		</section>
 	{/if}
+
+	{#if [...correct, ...incorrect].length > 0}
+		<section>
+			<h2>Kana times</h2>
+			<SummaryBox
+				time
+				items={[...correct, ...incorrect].sort(
+					(a, b) => b.duration - a.duration
+				)}
+				truncateAt={10}
+			/>
+		</section>
+	{/if}
 </div>
 
 <MenuBar class="glass-morphism">
 	<div class="menu content-width content-padding center">
 		{#if unquizzed.length > 0}
-			<p>There are {unquizzed.length} left to quiz. Finish up?</p>
+			<p>
+				There {unquizzed.length === 1 ? "is" : "are"}
+				{unquizzed.length} left to quiz. Finish up?
+			</p>
 		{/if}
 		<div class="menu-items">
 			{#if unquizzed.length > 0}
-				<Button href="/session">
+				<Button href="/session" on:click={() => quiz.refreshTime()}>
 					<Icon path={mdiArrowLeft} size="1.25em" />
 					Keep going
 				</Button>

--- a/src/routes/summary/index.svelte
+++ b/src/routes/summary/index.svelte
@@ -89,7 +89,7 @@
 
 	{#if [...correct, ...incorrect].length > 0}
 		<section>
-			<h2>Kana times</h2>
+			<h2>Time to response</h2>
 			<SummaryBox
 				time
 				items={[...correct, ...incorrect].sort(
@@ -111,7 +111,7 @@
 		{/if}
 		<div class="menu-items">
 			{#if unquizzed.length > 0}
-				<Button href="/session" on:click={() => quiz.refreshTime()}>
+				<Button href="/session">
 					<Icon path={mdiArrowLeft} size="1.25em" />
 					Keep going
 				</Button>

--- a/src/stores/quiz.ts
+++ b/src/stores/quiz.ts
@@ -12,16 +12,12 @@ export interface QuizItem {
 }
 
 export interface Quiz {
-	time: number
-	duration: number
 	unquizzed: QuizItem[]
 	quizzed: QuizItem[]
 }
 
 function createQuiz(dictionary: string[]): Quiz {
 	return {
-		time: Date.now(),
-		duration: 0,
 		unquizzed: shuffleArray(dictionary).map((kana) => ({ kana })),
 		quizzed: []
 	}
@@ -30,8 +26,6 @@ function createQuiz(dictionary: string[]): Quiz {
 export interface QuizStore extends Readable<Quiz> {
 	insert(index: number, item: QuizItem): void
 	pop(callback: (item: QuizItem) => QuizItem): void
-	refreshTime(): void
-	updateDuration(): void
 	reset(): void
 }
 
@@ -64,24 +58,11 @@ export function createQuizStore(): QuizStore {
 			})
 		},
 		pop(callback) {
-			update(({ unquizzed, quizzed, ...state }) => ({
-				...state,
+			update(({ unquizzed, quizzed }) => ({
 				// remove item from unquizzed
 				unquizzed: unquizzed.slice(1),
 				// add kana to quizzed array
 				quizzed: [...quizzed, callback(unquizzed[0])]
-			}))
-		},
-		refreshTime() {
-			update(({ time, ...state }) => ({
-				...state,
-				time: Date.now()
-			}))
-		},
-		updateDuration() {
-			update(({ duration, ...state }) => ({
-				...state,
-				duration: duration + Date.now() - state.time
 			}))
 		},
 		reset() {

--- a/src/stores/summary.ts
+++ b/src/stores/summary.ts
@@ -7,12 +7,14 @@ export interface SummaryKana {
 	kana: string
 	answers: string[]
 	incorrectTimes: number
+	duration: number
 }
 
 interface Summary {
 	incorrect: SummaryKana[]
 	correct: SummaryKana[]
 	unquizzed: SummaryKana[]
+	duration: number
 }
 
 export const summary = derived(quiz, ($quiz): Summary => {
@@ -26,7 +28,8 @@ export const summary = derived(quiz, ($quiz): Summary => {
 			incorrectTimes: isCorrectAnswer
 				? 0
 				: dupes.filter((item) => item.isCorrectAnswer === isCorrectAnswer)
-						.length
+						.length,
+			duration: dupes.reduce((sum, item) => sum + item.duration, 0)
 		}
 	}
 
@@ -37,6 +40,7 @@ export const summary = derived(quiz, ($quiz): Summary => {
 		correct: uniqQuizzed
 			.filter((item) => item.isCorrectAnswer)
 			.map(createSummaryKana),
-		unquizzed: $quiz.unquizzed.map(createSummaryKana)
+		unquizzed: $quiz.unquizzed.map(createSummaryKana),
+		duration: $quiz.duration / 1000
 	}
 })

--- a/src/stores/summary.ts
+++ b/src/stores/summary.ts
@@ -41,6 +41,6 @@ export const summary = derived(quiz, ($quiz): Summary => {
 			.filter((item) => item.isCorrectAnswer)
 			.map(createSummaryKana),
 		unquizzed: $quiz.unquizzed.map(createSummaryKana),
-		duration: $quiz.duration / 1000
+		duration: $quiz.quizzed.reduce((sum, item) => sum + item.duration, 0) / 1000
 	}
 })


### PR DESCRIPTION
This adds the functionality mentioned in #223 to keep track of how much time is spent on each kana as well as the overall session.

The session time is appended to the stats at the top, and the individual kana times are added as a new section at the bottom of the summary page.

I sorted the kana by worst times, with the top 10 shown before truncating.

![image](https://github.com/user-attachments/assets/0169b92a-af04-43f6-a3e0-226ad7e362a2)